### PR TITLE
Reenable magithub

### DIFF
--- a/layers/+source-control/github/packages.el
+++ b/layers/+source-control/github/packages.el
@@ -15,8 +15,7 @@
         github-clone
         github-search
         magit-gh-pulls
-        ;; disabled for now, waiting for the new implementation of the project
-        ;; magithub
+        magithub
         ;; this package does not exits, we need it to wrap
         ;; the call to spacemacs/declare-prefix.
         (spacemacs-github :location built-in)


### PR DESCRIPTION
Ghub and therefore magithub now support creating tokens automatically:

https://github.com/vermiculus/magithub/blob/master/magithub.org#authentication
https://magit.vc/manual/ghub/Interactively-Creating-and-Storing-a-Token.html#Interactively-Creating-and-Storing-a-Token

Thank you for contributing to Spacemacs!

Before you submit this pull request, please ensure it is against the develop branch and not master.

This message should be replaced with a description of your change.

Thank you <3